### PR TITLE
ci: use Node.js 10.13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.2.1
+      - image: circleci/node:10.13.0
 
     steps:
       - checkout


### PR DESCRIPTION
Node.js 10 is the current LTS branch so we should test against it.