### PR TITLE
Make demo.end() return a promise

### DIFF
--- a/src/scripts/components/player/player.js
+++ b/src/scripts/components/player/player.js
@@ -7,7 +7,7 @@ export class Player {
     this.desktop = new Desktop(container);
     this.setCurrentStep(0);
   }
-  play(){
+  play(onComplete){
     let currentStep = this.getCurrentStep();
     if(currentStep < this.steps.length){
       const step = this.steps[currentStep];
@@ -15,6 +15,8 @@ export class Player {
         this.setCurrentStep(currentStep + 1);
         this.play();
       }, step.onCompleteDelay);
+    } else if(onComplete) {
+      onComplete();
     }
   }
   getCurrentStep(){

--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -47,6 +47,8 @@ export default class {
   }
   end(){
     const player = new Player(this.container, this.steps);
-    player.play();
+    return new Promise(resolve => {
+      player.play(resolve);
+    });
   }
 }


### PR DESCRIPTION
Make demo.end() return a promise, then we can stop and do something before we go on.

```js
// Constructor receives a selector that indicates
// where to inject the demonstration in your page.
(async function() {

const demo = new GDemo('#container');

const code = `
function greet(){
  console.log("Hello World!");
}

greet();
`

const steps1 = demo
  .openApp('editor', {minHeight: '350px', windowTitle: 'demo.js'})
  .write(code, {onCompleteDelay: 1500})
  .end();

const steps2 = demo
  .openApp('terminal', {minHeight: '350px', promptString: '$'})
  .command('node ./demo', {onCompleteDelay: 500})
  .respond('Hello World!')
  .command('')
  .end();

await steps1;

// paused and do sth.
...

await steps2;

}());
```