### PR TITLE
Make end method return a promise

### DIFF
--- a/src/scripts/components/player/player.js
+++ b/src/scripts/components/player/player.js
@@ -5,23 +5,33 @@ export class Player {
     this.container = container;
     this.steps = steps;
     this.desktop = new Desktop(container);
-    this.setCurrentStep(0);
+    this.setCurrentStepNumber(0);
   }
   play(){
-    let currentStep = this.getCurrentStep();
-    if(currentStep < this.steps.length){
-      const step = this.steps[currentStep];
-      playStep(this.desktop, step, () => {
-        this.setCurrentStep(currentStep + 1);
-        this.play();
-      }, step.onCompleteDelay);
-    }
+    return new Promise((resolve, reject) => {
+      playSteps(this, this.desktop, this.steps, () => {
+        resolve();
+      });
+    });
   }
-  getCurrentStep(){
-    return this.currentStep;
+  getCurrentStepNumber(){
+    return this.currentStepNumber;
   }
-  setCurrentStep(stepNumber){
-    this.currentStep = stepNumber;
+  setCurrentStepNumber(stepNumber){
+    this.currentStepNumber = stepNumber;
+  }
+}
+
+function playSteps(player, desktop, steps, onComplete){
+  let currentStepNumber = player.getCurrentStepNumber();
+  if(currentStepNumber < steps.length){
+    const step = steps[currentStepNumber];
+    playStep(desktop, step, () => {
+      player.setCurrentStepNumber(currentStepNumber + 1);
+      playSteps(player, desktop, steps, onComplete);
+    }, step.onCompleteDelay);
+  } else {
+    onComplete();
   }
 }
 

--- a/src/scripts/components/player/player.test.js
+++ b/src/scripts/components/player/player.test.js
@@ -36,9 +36,9 @@ describe('Player Component', () => {
     expect(player.desktop).toBeDefined();
   });
 
-  it('should set current step as zero on instantiate', () => {
+  it('should set current step number number as zero on instantiate', () => {
     const player = instantiatePlayer();
-    expect(player.currentStep).toEqual(0);
+    expect(player.currentStepNumber).toEqual(0);
   });
 
   it('should open step application when playing some step', () => {
@@ -84,7 +84,7 @@ describe('Player Component', () => {
     expect(typeof application.write.mock.calls[0][1]).toEqual('function');
   });
 
-  it('should increment current step after play some step', () => {
+  it('should increment current step number after play some step', () => {
     const steps = [
       {app: 'terminal', action: 'command'},
       {app: 'terminal', action: 'respond'}
@@ -94,15 +94,15 @@ describe('Player Component', () => {
     player.desktop.openApplication.mockReturnValue(application);
     player.play();
     jest.runOnlyPendingTimers();
-    expect(player.currentStep).toEqual(1);
+    expect(player.currentStepNumber).toEqual(1);
     jest.runOnlyPendingTimers();
-    expect(player.currentStep).toEqual(2);
+    expect(player.currentStepNumber).toEqual(2);
   });
 
   it('should optionally delay to play the next step', () => {
     const steps = [
       {app: 'terminal', action: 'command', params: {}, onCompleteDelay: 500},
-      {app: 'terminal', action: 'respond', params: {},}
+      {app: 'terminal', action: 'respond', params: {}}
     ];
     const player = instantiatePlayer(steps);
     const application = mockMaximizedTerminalApplication();
@@ -113,6 +113,30 @@ describe('Player Component', () => {
     expect(application.respond).not.toHaveBeenCalled();
     jest.advanceTimersByTime(1);
     expect(application.respond).toHaveBeenCalled();
+  });
+
+  it('should return a promise when playing steps', () => {
+    const steps = [];
+    const player = instantiatePlayer(steps);
+    const promise = player.play();
+    expect(promise.then).toBeDefined();
+  });
+
+  it('should resolve promise when finish to play steps', done => {
+    let resolved;
+    const steps = [
+      {app: 'terminal', action: 'command', params: {}},
+      {app: 'terminal', action: 'respond', params: {}}
+    ];
+    const player = instantiatePlayer(steps);
+    const application = mockMaximizedTerminalApplication();
+    player.desktop.openApplication.mockReturnValue(application);
+    player.play().then(() => {
+      resolved = true;
+      expect(resolved).toEqual(true);
+      done()
+    });
+    jest.runAllTimers();
   });
 
 });

--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -47,6 +47,6 @@ export default class {
   }
   end(){
     const player = new Player(this.container, this.steps);
-    player.play();
+    return player.play();
   }
 }


### PR DESCRIPTION
Resolves: https://github.com/glorious-codes/glorious-demo/issues/48

This PR makes possible to perform some action at the end of the demonstration.
Now, The `end()` method returns a promise.

**Example**
``` javascript
const containerElementSelector = '[data-container]';
  const gdemo = new GDemo(containerElementSelector);
  gdemo.openApp('terminal', {minHeight: '300px'})
    .command('node demo.js', {onCompleteDelay: 300})
    .respond('Hello World!', {onCompleteDelay: 1000})
    .end()
    .then(() => {
      const container = document.querySelector(containerElementSelector);
      container.classList.add('container-out');
    });
```

``` css
body {
  margin: 0;
  padding: 0;
}

.container {
  position: absolute;
  top: 100px;
  left: 50%;
  width: 400px;
  height: 300px;
  transform: translateX(-50%);
  transition: all 1s;
}

.container-out {
  top: -500px;
}
```

**Preview**
![2019-01-20 13 06 51](https://user-images.githubusercontent.com/4738687/51441016-5bb83280-1cb4-11e9-86a4-848516c58601.gif)
