### PR TITLE
Open editor application with initial content

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ const openAppOptions = {
   minHeight: '350px',
   windowTitle: 'bash',
   promptString: '~/my-project $', // for 'terminal' applications only
+  initialContent: 'Some text', // for 'editor' applications only
   inanimate: true // Turns off application's window animation
   onCompleteDelay: 1000 // Delay before executing the next method
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@glorious/demo",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glorious/demo",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "The easiest way to demonstrate your code in action",
   "main": "dist/gdemo.min.js",
   "files": [

--- a/src/mocks/editor-line-mock.js
+++ b/src/mocks/editor-line-mock.js
@@ -4,7 +4,7 @@ export const editorLineInstanceMock = {
   write: jest.fn((textLine, onComplete) => {
     onComplete();
   }),
-  element: '<div>Something</div>'
+  element: document.createElement('div')
 };
 
 export const EditorLineMock = jest.fn(() => {

--- a/src/scripts/components/editor-application/editor-application.js
+++ b/src/scripts/components/editor-application/editor-application.js
@@ -8,13 +8,31 @@ export class EditorApplication extends Application {
     super('editor', options);
     this.container = container;
     this.container.appendChild(this.element);
-    this.lines = [];
+    this.setupInitialContent(options.initialContent);
     this.setWindowTitle(buildWindowTitle(options));
   }
+  setupInitialContent(initialContent = ''){
+    const linesToAppend = parseContent(initialContent);
+    this.setLines([]);
+    this.appendLines(linesToAppend);
+  }
+  setLines(lines){
+    this.lines = [];
+  }
+  appendLines(textLines){
+    textLines.forEach(textLine => {
+      const line = buildEditorLine(this.lines, textLine);
+      appendContentToApplication(this, line);
+    });
+  }
   write({ codeSample }, onComplete){
-    const textLines = textService.removeBlankFirstLine(codeSample);
+    const textLines = parseContent(codeSample);
     writeMultipleLines(this, textLines, onComplete);
   }
+}
+
+function parseContent(content){
+  return textService.removeBlankFirstLine(content);
 }
 
 function buildWindowTitle(options){
@@ -38,10 +56,18 @@ function inactivateLastLineWritten(lines){
     lines[lines.length-1].setInactive();
 }
 
-function writeSingleLine(application, textLine, onComplete){
-  const line = new EditorLine(application.lines.length + 1);
+function writeSingleLine(application, text, onComplete){
+  const line = buildEditorLine(application.lines);
+  appendContentToApplication(application, line);
+  line.setActive();
+  line.write(text, onComplete);
+}
+
+function buildEditorLine(applicationLines, text){
+  return new EditorLine(applicationLines.length + 1, text);
+}
+
+function appendContentToApplication(application, line){
   application.addContent(line.element);
   application.lines.push(line);
-  line.setActive();
-  line.write(textLine, onComplete);
 }

--- a/src/scripts/components/editor-application/editor-application.test.js
+++ b/src/scripts/components/editor-application/editor-application.test.js
@@ -22,6 +22,15 @@ describe('Editor Application Component', () => {
     expect(application.element.classList[0]).toEqual('editor-application');
   });
 
+  it('should append lines on instantiate if initial content has been given', () => {
+    const initialContent = `Some text.
+Some more text.`;
+    const application = instantiateEditorApplication({ initialContent });
+    expect(EditorLineMock).toHaveBeenCalledWith(1, 'Some text.');
+    expect(EditorLineMock).toHaveBeenCalledWith(2, 'Some more text.');
+    expect(application.lines.length).toEqual(2);
+  });
+
   it('should config window title with default window title if no window title option is given', () => {
     const application = instantiateEditorApplication();
     expect(application.windowTitle).toEqual('~/demo/demo.js');
@@ -43,14 +52,14 @@ describe('Editor Application Component', () => {
     expect(application.addContent).toHaveBeenCalledWith(editorLineInstanceMock.element);
   });
 
-  it('should instance a editor application line when writing some code', () => {
+  it('should instantiate an editor application line when writing some code', () => {
     const application = instantiateEditorApplication();
     const codeSample = 'Line 1';
     const onComplete = jest.fn();
     application.addContent = jest.fn();
     stubRemoveBlankFirstLine(codeSample.split('\n'));
     application.write({ codeSample }, onComplete);
-    expect(EditorLineMock).toHaveBeenCalledWith(1);
+    expect(EditorLineMock).toHaveBeenCalledWith(1, undefined);
   });
 
   it('should set line as active on write', () => {

--- a/src/scripts/components/editor-line/editor-line.js
+++ b/src/scripts/components/editor-line/editor-line.js
@@ -4,11 +4,13 @@ import domService from '../../services/dom/dom';
 import template from './editor-line.html';
 
 export class EditorLine {
-  constructor(lineNumber){
+  constructor(lineNumber, writtenText){
     this.cursor = new Cursor();
     this.element = domService.parseHtml(template);
-    getTextElement(this.element).appendChild(this.cursor.element);
     setNumber(this.element, lineNumber);
+    setupWrittenText(this.element, writtenText);
+    if(!writtenText)
+      getTextElement(this.element).appendChild(this.cursor.element);
   }
   write(text, onComplete){
     this.cursor.write(text, onComplete);
@@ -35,4 +37,8 @@ function getTextElement(lineElement){
 
 function getInnerElement(lineElement, selector){
   return lineElement.querySelector(selector);
+}
+
+function setupWrittenText(lineElement, text = ''){
+  getTextElement(lineElement).innerHTML = text;
 }

--- a/src/scripts/components/editor-line/editor-line.test.js
+++ b/src/scripts/components/editor-line/editor-line.test.js
@@ -12,7 +12,7 @@ describe('Editor Line Component', () => {
     spyOn(typeService, 'type');
   });
 
-  it('should build editor line on instantiate', () => {
+  it('should have appropriate css class', () => {
     const line = new EditorLine();
     expect(line.element.classList[0]).toEqual('editor-line');
   });
@@ -27,6 +27,12 @@ describe('Editor Line Component', () => {
     const line = new EditorLine(1);
     const cursorElement = line.element.querySelectorAll('[data-editor-line-text] > span');
     expect(cursorElement.length).toEqual(1);
+  });
+
+  it('should not append a cursor element if line contains some written text on instantiate', () => {
+    const line = new EditorLine(1, 'Some text');
+    const cursorElement = line.element.querySelectorAll('[data-editor-line-text] > span');
+    expect(cursorElement.length).toEqual(0);
   });
 
   it('should write some text using cursor', () => {


### PR DESCRIPTION
Resolves #62 

![2020-04-15 21 07 54](https://user-images.githubusercontent.com/4738687/79404891-53a77b00-7f69-11ea-9b91-30070838c995.gif)

After releasing these changes, users will be able to open an editor in the following ways:

1) Normal Mode
2) Inanimate Mode
3) Initial Content Mode